### PR TITLE
Avoid pickling simulation_runners before complete initialisation

### DIFF
--- a/a3fe/run/_simulation_runner.py
+++ b/a3fe/run/_simulation_runner.py
@@ -55,6 +55,7 @@ class SimulationRunner(ABC):
         dg_multiplier: int = 1,
         ensemble_size: int = 5,
         update_paths: bool = True,
+        dump: bool = True,
     ) -> None:
         """
         base_dir : str, Optional, default: None
@@ -80,6 +81,8 @@ class SimulationRunner(ABC):
         update_paths: bool, Optional, default: True
             If True, if the simulation runner is loaded by unpickling, then
             update_paths() is called.
+        dump: bool, Optional, default: True
+            If True, the state of the simulation runner is saved to a pickle file.
         """
         # Set up the directories (which may be overwritten if the
         # simulation runner is subsequently loaded from a pickle file)
@@ -140,7 +143,8 @@ class SimulationRunner(ABC):
             self._set_up_logging()
 
             # Save state
-            self._dump()
+            if dump:
+                self._dump()
 
     def _set_up_logging(self, null: bool = False) -> None:
         """

--- a/a3fe/run/calculation.py
+++ b/a3fe/run/calculation.py
@@ -93,6 +93,7 @@ class Calculation(_SimulationRunner):
             stream_log_level=stream_log_level,
             ensemble_size=ensemble_size,
             update_paths=update_paths,
+            dump=False,
         )
 
         if not self.loaded_from_pickle:

--- a/a3fe/run/lambda_window.py
+++ b/a3fe/run/lambda_window.py
@@ -122,6 +122,7 @@ class LamWindow(_SimulationRunner):
             stream_log_level=stream_log_level,
             ensemble_size=ensemble_size,
             update_paths=update_paths,
+            dump=False,
         )
 
         if not self.loaded_from_pickle:

--- a/a3fe/run/leg.py
+++ b/a3fe/run/leg.py
@@ -119,6 +119,7 @@ class Leg(_SimulationRunner):
             stream_log_level=stream_log_level,
             ensemble_size=ensemble_size,
             update_paths=update_paths,
+            dump=False,
         )
 
         if not self.loaded_from_pickle:

--- a/a3fe/run/simulation.py
+++ b/a3fe/run/simulation.py
@@ -103,6 +103,7 @@ class Simulation(_SimulationRunner):
             output_dir=output_dir,
             stream_log_level=stream_log_level,
             update_paths=update_paths,
+            dump=False,
         )
 
         if not self.loaded_from_pickle:

--- a/a3fe/run/stage.py
+++ b/a3fe/run/stage.py
@@ -146,6 +146,7 @@ class Stage(_SimulationRunner):
             stream_log_level=stream_log_level,
             ensemble_size=ensemble_size,
             update_paths=update_paths,
+            dump=False,
         )
 
         if not self.loaded_from_pickle:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Change Log
 ===============
 
+v0.1.1
+
+- Ensured that ``simulation_runner`` objects only get pickled once they've been fully initialised. This avoids issues where an error occurs during initialisation and the object is pickled in an incomplete state. Addresses https://github.com/michellab/a3fe/issues/1.
+
 v0.1.0
 ====================
 


### PR DESCRIPTION
This should close https://github.com/michellab/a3fe/issues/1.

## Description
Ensure that ``simulation_runner`` objects only get pickled once they've been fully initialised. This avoids issues where an error occurs during initialisation and the object is pickled in an incomplete state.

## Status
- [x] Ready to go