### PR TITLE
Bugfix rename equil files

### DIFF
--- a/a3fe/run/leg.py
+++ b/a3fe/run/leg.py
@@ -645,9 +645,11 @@ class Leg(_SimulationRunner):
                 )
 
         # Give the output files unique names
-        for i, outdir in enumerate(outdirs_to_run):
+        equil_numbers = [int(outdir.split("_")[-1]) for outdir in outdirs_to_run]
+        for equil_number, outdir in zip(equil_numbers, outdirs_to_run):
             _subprocess.run(
-                ["mv", f"{outdir}/somd.rst7", f"{outdir}/somd_{i + 1}.rst7"], check=True
+                ["mv", f"{outdir}/somd.rst7", f"{outdir}/somd_{equil_number}.rst7"],
+                check=True,
             )
 
         # Load the system and mark the ligand to be decoupled

--- a/a3fe/run/system_prep.py
+++ b/a3fe/run/system_prep.py
@@ -675,7 +675,7 @@ def run_ensemble_equilibration(
 
     # Run - assuming that this will be in the appropriate ensemble equilibration directory
     print(
-        f"Running SOMD ensemble equilibration simulation for {cfg.ensemble_equilibration_time} ps"
+        f"Running ensemble equilibration simulation with GROMACS for {cfg.ensemble_equilibration_time} ps"
     )
     if leg_type == _LegType.BOUND:
         work_dir = output_dir

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Change Log
 ===============
 
+0.3.2
+====================
+- Fix bug which caused somd.rst7 files in the ensemble equilibration directories to be incorrectly numbered in some cases.
+
 0.3.1
 ====================
 - Modified the SimulationRunnerIterator to ensure that the state of sub-simulation runners is saved before they are torn down. This means that setting the equilibration time at the CalcSet level will now work as expected (previously the state of the calculations was not saved, causing the analysis to fail).


### PR DESCRIPTION
## Description
Ensure somd.rst7 is correctly named during equilibration.

Closes https://github.com/michellab/a3fe/issues/35 .

## Status
- [x] Ready to go

Could you please review @Roy-Haolin-Du 