### PR TITLE
Bugfix CI failing by forcing to retrieve the MKL package from the conda-forge channel

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,7 +23,7 @@ dependencies:
   - gromacs
   - pydantic
   - ruff
-  - conda-forge::mkl>=2022.1.0
+  - mkl>=2022.1.0
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,7 +23,7 @@ dependencies:
   - gromacs
   - pydantic
   - ruff
-  - conda-forge::mkl
+  - conda-forge::mkl>=2022.1.0
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,6 +23,7 @@ dependencies:
   - gromacs
   - pydantic
   - ruff
+  - conda-forge::mkl
 
     # Testing
   - pytest


### PR DESCRIPTION
## Description

- Our CI tests ran successfully across all Python versions (3.10, 3.11, 3.12) last week. However, this week the same code began failing specifically in Python 3.11 environments, while continuing to pass in 3.10 and 3.12. The failure manifested during the parameterization process where AmberTools' Antechamber component reported it could not find the `libmkl_core.so.2` shared library.
- Resolving this issue with the following modification to our environment file(devtools/conda-envs/test_env.yaml):

```yaml
dependencies:
  # Other dependencies unchanged
  - conda-forge::mkl>=2022.1.0  # Explicitly specify MKL from conda-forge channel
```
Close https://github.com/michellab/a3fe/issues/41. 

## Status
- [x] Ready to go
- [x] Pass all CI test

Could you please review? @fjclark 