### PR TITLE
Bugfix repeats runs_nos in get_water_stage()

### DIFF
--- a/a3fe/analyse/waters.py
+++ b/a3fe/analyse/waters.py
@@ -232,7 +232,6 @@ def get_av_waters_stage(
                     run_nos,
                     index2,
                     length2,
-                    run_nos,
                     print_fn,
                 )
                 for lam_window in lam_windows


### PR DESCRIPTION
## Description
Removing repeats run_nos in get_av_waters_stage() functions to analyse binding site waters to aovid wrong numbers of positional arguments.

Close  https://github.com/michellab/a3fe/issues/43. 

## Status
- [x] Ready to go

Super minor bug. I will merge it.

Thanks.