### PR TITLE
Update defaults for runtime_constant and delta_er

### DIFF
--- a/a3fe/analyse/process_grads.py
+++ b/a3fe/analyse/process_grads.py
@@ -312,7 +312,8 @@ class GradientData:
             between each lambda value, in kcal mol^(-1). If er_type == "sem", the
             desired integrated standard error of the mean of the gradients between each lambda
             value, in kcal mol^(-1) ns^(1/2). If not provided, the number of lambda
-            windows must be provided with n_lam_vals.
+            windows must be provided with n_lam_vals. This is referred to as 'thermodynamic speed'
+            in the publication.
         n_lam_vals : int, optional
             The number of lambda values to sample. If not provided, delta_er must be provided.
         sem_origin: str, optional, default="inter"

--- a/a3fe/run/calc_set.py
+++ b/a3fe/run/calc_set.py
@@ -167,7 +167,7 @@ class CalcSet(_SimulationRunner):
         self,
         simtime: float = 0.1,
         er_type: str = "root_var",
-        delta_er: float = 1,
+        delta_er: float = 2,
         set_relative_sim_cost: bool = True,
         reference_sim_cost: float = 0.21,
         run_nos: _List[int] = [1],
@@ -188,12 +188,13 @@ class CalcSet(_SimulationRunner):
             Whether to integrate the standard error of the mean ("sem") or root
             variance of the gradients ("root_var") to calculate the optimal
             lambda values.
-        delta_er : float, default=1
+        delta_er : float, default=2
             If er_type == "root_var", the desired integrated root variance of the gradients
             between each lambda value, in kcal mol^(-1). If er_type == "sem", the
             desired integrated standard error of the mean of the gradients between each lambda
-            value, in kcal mol^(-1) ns^(1/2). A sensible default for root_var is 1 kcal mol-1,
-            and 0.1 kcal mol-1 ns^(1/2) for sem.
+            value, in kcal mol^(-1) ns^(1/2). A sensible default for root_var is 2 kcal mol-1,
+            and 0.1 kcal mol-1 ns^(1/2) for sem. This is referred to as 'thermodynamic speed'
+            in the publication.
         set_relative_sim_cost: bool, optional, default=True
             Whether to recursively set the relative simulation cost for the leg and all
             sub simulation runners according to the mean simulation cost of the leg.

--- a/a3fe/run/calculation.py
+++ b/a3fe/run/calculation.py
@@ -35,7 +35,7 @@ class Calculation(_SimulationRunner):
     def __init__(
         self,
         equil_detection: str = "multiwindow",
-        runtime_constant: _Optional[float] = 0.001,
+        runtime_constant: _Optional[float] = 0.0005,
         relative_simulation_cost: float = 1,
         ensemble_size: int = 5,
         input_dir: _Optional[str] = None,
@@ -55,14 +55,10 @@ class Calculation(_SimulationRunner):
             - "multiwindow": Use the multiwindow paired t-test method to detect equilibration.
                              This is applied on a per-stage basis.
             - "chodera": Use Chodera's method to detect equilibration.
-        runtime_constant: float, Optional, default: 0.001
+        runtime_constant: float, Optional, default: 0.0005
             The runtime_constant (kcal**2 mol**-2 ns*-1) only affects behaviour if running adaptively, and must
             be supplied if running adaptively. This is used to calculate how long to run each simulation for based on
             the current uncertainty of the per-window free energy estimate, as discussed in the docstring of the run() method.
-        runtime_constant : float, Optional, default: 0.001
-            The runtime constant to use for the calculation, in kcal^2 mol^-2 ns^-1.
-            This must be supplied if running adaptively. Each window is run until the
-            SEM**2 / runtime >= runtime_constant.
         relative_simlation_cost : float, Optional, default: 1
             The relative cost of the simulation for a given runtime. This is used to calculate the
             predicted optimal runtime during adaptive simulations. The recommended use
@@ -218,7 +214,7 @@ class Calculation(_SimulationRunner):
         self,
         simtime: float = 0.1,
         er_type: str = "root_var",
-        delta_er: float = 1,
+        delta_er: float = 2,
         set_relative_sim_cost: bool = True,
         reference_sim_cost: float = 0.21,
         run_nos: _List[int] = [1],
@@ -237,12 +233,13 @@ class Calculation(_SimulationRunner):
             Whether to integrate the standard error of the mean ("sem") or root
             variance of the gradients ("root_var") to calculate the optimal
             lambda values.
-        delta_er : float, default=1
+        delta_er : float, default=2
             If er_type == "root_var", the desired integrated root variance of the gradients
             between each lambda value, in kcal mol^(-1). If er_type == "sem", the
             desired integrated standard error of the mean of the gradients between each lambda
-            value, in kcal mol^(-1) ns^(1/2). A sensible default for root_var is 1 kcal mol-1,
-            and 0,1 kcal mol-1 ns^(1/2) for sem.
+            value, in kcal mol^(-1) ns^(1/2). A sensible default for root_var is 2 kcal mol-1,
+            and 0,1 kcal mol-1 ns^(1/2) for sem. This is referred to as 'thermodynamic speed'
+            in the publication.
         set_relative_sim_cost: bool, optional, default=True
             Whether to recursively set the relative simulation cost for the leg and all
             sub simulation runners according to the mean simulation cost of the leg.

--- a/a3fe/run/lambda_window.py
+++ b/a3fe/run/lambda_window.py
@@ -43,7 +43,7 @@ class LamWindow(_SimulationRunner):
         equil_detection: str = "multiwindow",
         slurm_equil_detection: bool = True,
         gradient_threshold: _Optional[float] = None,
-        runtime_constant: _Optional[float] = 0.005,
+        runtime_constant: _Optional[float] = 0.0005,
         relative_simulation_cost: float = 1,
         ensemble_size: int = 5,
         base_dir: _Optional[str] = None,
@@ -80,7 +80,7 @@ class LamWindow(_SimulationRunner):
             set and the simulation is equilibrated when the gradient passes through 0. A
             sensible value appears to be 0.5 kcal mol-1 ns-1. Only required when the equilibration
             detection method is "block_gradient".
-        runtime_constant: float, Optional, default: 0.005
+        runtime_constant: float, Optional, default: 0.0005
             The runtime_constant (kcal**2 mol**-2 ns*-1) only affects behaviour if running adaptively, and must
             be supplied if running adaptively. This is used to calculate how long to run each simulation for based on
             the current uncertainty of the per-window free energy estimate, as discussed in the docstring of the run() method.

--- a/a3fe/run/leg.py
+++ b/a3fe/run/leg.py
@@ -62,7 +62,7 @@ class Leg(_SimulationRunner):
         self,
         leg_type: _LegType,
         equil_detection: str = "multiwindow",
-        runtime_constant: _Optional[float] = 0.005,
+        runtime_constant: _Optional[float] = 0.0005,
         relative_simulation_cost: float = 1,
         ensemble_size: int = 5,
         base_dir: _Optional[str] = None,
@@ -83,7 +83,7 @@ class Leg(_SimulationRunner):
             Method to use for equilibration detection. Options are:
             - "multiwindow": Use the multiwindow paired t-test method to detect equilibration.
             - "chodera": Use Chodera's method to detect equilibration.
-        runtime_constant: float, Optional, default: 0.005
+        runtime_constant: float, Optional, default: 0.0005
             The runtime_constant (kcal**2 mol**-2 ns*-1) only affects behaviour if running adaptively, and must
             be supplied if running adaptively. This is used to calculate how long to run each simulation for based on
             the current uncertainty of the per-window free energy estimate, as discussed in the docstring of the run() method.
@@ -276,7 +276,7 @@ class Leg(_SimulationRunner):
         self,
         simtime: _Optional[float] = 0.1,
         er_type: str = "root_var",
-        delta_er: float = 1,
+        delta_er: float = 2,
         set_relative_sim_cost: bool = True,
         reference_sim_cost: float = 0.21,
         run_nos: _List[int] = [1],
@@ -297,12 +297,13 @@ class Leg(_SimulationRunner):
             Whether to integrate the standard error of the mean ("sem") or root
             variance of the gradients ("root_var") to calculate the optimal
             lambda values.
-        delta_er : float, default=1
+        delta_er : float, default=2
             If er_type == "root_var", the desired integrated root variance of the gradients
             between each lambda value, in kcal mol^(-1). If er_type == "sem", the
             desired integrated standard error of the mean of the gradients between each lambda
-            value, in kcal mol^(-1) ns^(1/2). A sensible default for root_var is 1 kcal mol-1,
-            and 0.1 kcal mol-1 ns^(1/2) for sem.
+            value, in kcal mol^(-1) ns^(1/2). A sensible default for root_var is 2 kcal mol-1,
+            and 0.1 kcal mol-1 ns^(1/2) for sem. This is referred to as 'thermodynamic speed'
+            in the publication.
         set_relative_sim_cost: bool, optional, default=True
             Whether to recursively set the relative simulation cost for the leg and all
             sub simulation runners according to the mean simulation cost of the leg.

--- a/a3fe/run/stage.py
+++ b/a3fe/run/stage.py
@@ -79,7 +79,7 @@ class Stage(_SimulationRunner):
         self,
         stage_type: _StageType,
         equil_detection: str = "multiwindow",
-        runtime_constant: _Optional[float] = 0.005,
+        runtime_constant: _Optional[float] = 0.0005,
         relative_simulation_cost: float = 1,
         ensemble_size: int = 5,
         lambda_values: _Optional[_List[float]] = None,
@@ -102,7 +102,7 @@ class Stage(_SimulationRunner):
             Method to use for equilibration detection. Options are:
             - "multiwindow": Use the multiwindow paired t-test method to detect equilibration.
             - "chodera": Use Chodera's method to detect equilibration.
-        runtime_constant : float, Optional, default: 0.005
+        runtime_constant : float, Optional, default: 0.0005
             The runtime_constant (kcal**2 mol**-2 ns*-1) only affects behaviour if running adaptively, and must
             be supplied if running adaptively. This is used to calculate how long to run each simulation for based on
             the current uncertainty of the per-window free energy estimate, as discussed in the docstring of the run() method.
@@ -634,8 +634,8 @@ class Stage(_SimulationRunner):
             between each lambda value, in kcal mol^(-1). If er_type == "sem", the
             desired integrated standard error of the mean of the gradients between each lambda
             value, in kcal mol^(-1) ns^(1/2). A sensible default for sem is 0.1 kcal mol-1 ns1/2,
-            and for root_var is 1 kcal mol-1.  If not provided, the number of lambda windows must be
-            provided with n_lam_vals.
+            and for root_var is 2 kcal mol-1.  If not provided, the number of lambda windows must be
+            provided with n_lam_vals. This is referred to as 'thermodynamic speed' in the publication.
         n_lam_vals : int, optional, default=None
             The number of lambda values to sample. If not provided, delta_er must be provided.
         run_nos : List[int], optional, default=[1]

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Change Log
 ===============
 
+0.3.5
+====================
+- Changed the defaults for runtime_constants and thermodynamic speed ("delta_er") to be consistent with the optimised values in the publication (https://pubs.acs.org/doi/full/10.1021/acs.jctc.4c00806).
+
 0.3.4
 ====================
 - Added loguru to make dependency explicit in the environment.yaml and conda-envs/test_env.yaml files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 method = "git"  # <- The method name
 # Parameters to pass to the method:
 match = ["*"]
-default-tag = "0.3.1"
+default-tag = "0.3.4"
 
 [tool.versioningit.write]
 file = "a3fe/_version.py"


### PR DESCRIPTION
Make these consistent within a3fe and consistent with the values in the publication. Note that delta_er is referred to as "thermodynamic_speed" in the publication.

This closes https://github.com/michellab/a3fe/issues/61.

@Roy-Haolin-Du, could you please have a look? Also, would you mind running the integration tests if you think these need rerun, as I'm currently running other stuff on my workstation? No worries if you don't have the compute though. Thanks!