### PR TITLE
Add alchemlyb=1.0.1 to dev environment

### DIFF
--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -17,6 +17,7 @@ dependencies:
   - scipy
   - ipython
   - pymbar<4
+  - alchemlyb=1.0.1
   - ambertools
   - biosimspace>2023.4
   - numpydoc
@@ -36,4 +37,3 @@ dependencies:
 
     # Development tools
   - pre-commit
-


### PR DESCRIPTION
## Description
Add alchemlyb=1.0.1 to dev environment for longer term switch to pymbar 4.


## Status
- [x] Ready to go