### PR TITLE
Fix equilibration time unit conversion

### DIFF
--- a/a3fe/run/lambda_window.py
+++ b/a3fe/run/lambda_window.py
@@ -354,6 +354,7 @@ class LamWindow(_SimulationRunner):
         equil_index = (
             int(
                 self._equil_time
+                * 1_000_000
                 / (
                     self.sims[0].engine_config.timestep
                     * self.sims[0].engine_config.energy_frequency

--- a/a3fe/tests/test_calc_set.py
+++ b/a3fe/tests/test_calc_set.py
@@ -43,7 +43,7 @@ def test_calc_set_analysis(calc_set):
     )
 
     # Regression test for the results
-    assert results_exp.loc["t4l", "calc_dg"] == pytest.approx(5.2622, abs=1e-2)
-    assert results_exp.loc["t4l", "calc_er"] == pytest.approx(0.1138, abs=1e-2)
+    assert results_exp.loc["t4l", "calc_dg"] == pytest.approx(5.2850, abs=1e-2)
+    assert results_exp.loc["t4l", "calc_er"] == pytest.approx(0.0808, abs=1e-2)
     assert results_exp.loc["mdm2_short", "calc_dg"] == pytest.approx(7.9391, abs=1e-2)
     assert results_exp.loc["mdm2_short", "calc_er"] == pytest.approx(0.1679, abs=1e-2)


### PR DESCRIPTION
## Description
Fix the equilibration truncation time by converting equilibration time from ns to fs before slicing simfile data.


## Status
- [x] Ready to go